### PR TITLE
[MOBILE-BUTTON] Change Prepare Cookie button if is mobile device

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,8 @@
 module ApplicationHelper
+  def mobile_device
+    agent = request.user_agent
+    return "tablet" if agent =~ /(tablet|ipad)|(android(?!.*mobile))/i
+    return "mobile" if agent =~ /Mobile/
+    return "desktop"
+  end
 end

--- a/app/views/ovens/show.html.haml
+++ b/app/views/ovens/show.html.haml
@@ -1,5 +1,6 @@
 %h3= @oven.name
-
+- if mobile_device == "mobile"
+  = link_to "Prepare Cookie", new_oven_cookies_path(@oven), class: 'button'
 .cookie-info
   Cookie in oven:
   - if @oven.cookie
@@ -13,8 +14,8 @@
     None
 
 %br
-
-= link_to "Prepare Cookie", new_oven_cookies_path(@oven), class: 'button'
+- if mobile_device != "mobile"
+  = link_to "Prepare Cookie", new_oven_cookies_path(@oven), class: 'button'
 
 :javascript
   $(document).ready(function() {


### PR DESCRIPTION
## Feature
 As a bakery owner using the mobile web, I want my "Prepare Cookie" button to be first.

## Checklist:
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed locally.